### PR TITLE
chore: add CCAI team to samples CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,3 @@
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation
-
-/samples/   @googleapis/api-contact-center-insights

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 
 # The yoshi-nodejs team is the default owner for nodejs repositories.
-*     @googleapis/yoshi-nodejs
+*     @googleapis/yoshi-nodejs @googleapis/api-contact-center-insights
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,5 @@
 
 # The github automation team is the default owner for the auto-approve file.
 .github/auto-approve.yml @googleapis/github-automation
+
+/samples/   @googleapis/api-contact-center-insights

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,5 +10,6 @@
   "distribution_name": "@google-cloud/contact-center-insights",
   "api_id": "contactcenterinsights.googleapis.com",
   "default_version": "v1",
-  "requires_billing": true
+  "requires_billing": true,
+  "codeowner_team": "@googleapis/api-contact-center-insights"
 }


### PR DESCRIPTION
This PR adds the @googleapis/api-contact-center-insights team to the CODEOWNERS file for samples.
